### PR TITLE
Fix key normalization in cache

### DIFF
--- a/node/service/internal/cache/cache.go
+++ b/node/service/internal/cache/cache.go
@@ -49,9 +49,9 @@ func (c *InMemoryCache) getShard(key []byte) *CacheShard {
 }
 
 func (c *InMemoryCache) Set(key, value []byte, ttl time.Duration) {
+	key = normalizeKey(key)
 	strKey := base64.StdEncoding.EncodeToString(key)
 
-	key = normalizeKey(key)
 	shard := c.getShard(key)
 
 	shard.mu.Lock()
@@ -63,9 +63,9 @@ func (c *InMemoryCache) Set(key, value []byte, ttl time.Duration) {
 }
 
 func (c *InMemoryCache) Get(key []byte) ([]byte, bool) {
+	key = normalizeKey(key)
 	strKey := base64.StdEncoding.EncodeToString(key)
 
-	key = normalizeKey(key)
 	shard := c.getShard(key)
 
 	shard.mu.Lock()
@@ -82,6 +82,7 @@ func (c *InMemoryCache) Get(key []byte) ([]byte, bool) {
 }
 
 func (c *InMemoryCache) Delete(key []byte) {
+	key = normalizeKey(key)
 	strKey := base64.StdEncoding.EncodeToString(key)
 
 	shard := c.getShard(key)

--- a/node/service/internal/cache/cache_test.go
+++ b/node/service/internal/cache/cache_test.go
@@ -75,3 +75,17 @@ func TestCache_fnv32(t *testing.T) {
 	require.Equal(t, uint32(3069866343), fnv32([]byte("hello")))
 	require.Equal(t, uint32(2609808943), fnv32([]byte("world")))
 }
+
+func TestCacheNormalizedKeyRetrieval(t *testing.T) {
+	c := NewCache()
+	c.Set([]byte("café"), []byte("value"), 5*time.Minute)
+
+	val, ok := c.Get([]byte("cafe\u0301"))
+	require.True(t, ok)
+	require.EqualValues(t, "value", val)
+
+	c.Delete([]byte("cafe\u0301"))
+	val, ok = c.Get([]byte("café"))
+	require.Nil(t, val)
+	require.False(t, ok)
+}


### PR DESCRIPTION
## Summary
- normalize keys before encoding them for storage
- ensure Delete uses the normalized key
- add test for using a different key representation

## Testing
- `make test` *(fails: unable to download modules)*
