### PR TITLE
Improve cache performance and code readability

### DIFF
--- a/foundation/http/response.go
+++ b/foundation/http/response.go
@@ -45,14 +45,7 @@ func UnmarshalJSONFromBody(r *http.Request, target interface{}) (err error) {
 	}
 
 	if err := json.Unmarshal(bodyBytes, target); err != nil {
-		switch err.(type) {
-		case *json.SyntaxError:
-			return fmt.Errorf("while unmarshalling data from body: %w", err)
-		case *json.UnmarshalTypeError:
-			return fmt.Errorf("while unmarshalling data from body: %w", err)
-		default:
-			return fmt.Errorf("while unmarshalling data from body: %w", err)
-		}
+		return fmt.Errorf("while unmarshalling data from body: %w", err)
 	}
 
 	return nil

--- a/master/service/internal/api/http/handler.go
+++ b/master/service/internal/api/http/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
 
 	"github.com/go-chi/chi/v5"
 	httpFramework "github.com/mnabbasbaadi/distributedcache/foundation/http"
@@ -21,10 +22,25 @@ var (
 
 type (
 	server struct {
-		logger *slog.Logger
-		sh     hash.Hasher
+		logger  *slog.Logger
+		sh      hash.Hasher
+		clients sync.Map // map[string]*cacheAPI.ClientWithResponses
 	}
 )
+
+func (s *server) getClient(addr string) (*cacheAPI.ClientWithResponses, error) {
+	if c, ok := s.clients.Load(addr); ok {
+		return c.(*cacheAPI.ClientWithResponses), nil
+	}
+
+	client, err := cacheAPI.NewClientWithResponses(fmt.Sprintf("http://%s", addr))
+	if err != nil {
+		return nil, err
+	}
+
+	actual, _ := s.clients.LoadOrStore(addr, client)
+	return actual.(*cacheAPI.ClientWithResponses), nil
+}
 
 func (s server) AddKey(w http.ResponseWriter, r *http.Request) {
 
@@ -47,8 +63,7 @@ func (s server) AddKey(w http.ResponseWriter, r *http.Request) {
 		s.respondError(w, errKeyNotFound, http.StatusNotFound)
 		return
 	}
-	// TODO: use client from cache
-	client, err := cacheAPI.NewClientWithResponses(fmt.Sprintf("http://%s", url))
+	client, err := s.getClient(url)
 	if err != nil {
 		s.logger.With(err).Error("while creating client")
 		s.respondError(w, err, http.StatusInternalServerError)
@@ -70,8 +85,7 @@ func (s server) GetValue(w http.ResponseWriter, r *http.Request, key registerAPI
 		s.respondError(w, errKeyNotFound, http.StatusNotFound)
 		return
 	}
-	// TODO: use client from cache
-	client, err := cacheAPI.NewClientWithResponses(fmt.Sprintf("http://%s", url))
+	client, err := s.getClient(url)
 	if err != nil {
 		s.logger.With(err).Error("while creating client")
 		s.respondError(w, err, http.StatusInternalServerError)

--- a/master/service/internal/hash/hash_ring.go
+++ b/master/service/internal/hash/hash_ring.go
@@ -34,6 +34,7 @@ type (
 	}
 )
 
+// NewHashRing creates a hash ring with the given node addresses.
 func NewHashRing(addrs ...string) Hasher {
 	nodes := make([]node, len(addrs))
 	for i, addr := range addrs {
@@ -61,7 +62,7 @@ func (hr *hashRing) DeleteNode(address string) {
 
 // rehash pre-allocates the hashes array and fills it with the hash values of all nodes.
 func (hr *hashRing) rehash() {
-	hr.hashes = []uint32{}
+	hr.hashes = make([]uint32, 0, len(hr.nodes)*hashSpace)
 	for i, node := range hr.nodes {
 		for j := 0; j < hashSpace; j++ {
 			hr.hashes = append(hr.hashes, hashStr(fmt.Sprintf("%s-%d", node.address, i*hashSpace+j)))

--- a/node/service/internal/api/http/handler.go
+++ b/node/service/internal/api/http/handler.go
@@ -20,12 +20,12 @@ var (
 type (
 	server struct {
 		logger *slog.Logger
-		node   node.Node
+		node   node.CacheNode
 	}
 )
 
 // NewHandler returns a new http.Handler that implements the ServerInterface
-func NewHandler(logger *slog.Logger, node node.Node) http.Handler {
+func NewHandler(logger *slog.Logger, node node.CacheNode) http.Handler {
 	s := server{
 		logger: logger,
 		node:   node,

--- a/node/service/internal/cache/cache.go
+++ b/node/service/internal/cache/cache.go
@@ -68,13 +68,15 @@ func (c *InMemoryCache) Get(key []byte) ([]byte, bool) {
 
 	shard := c.getShard(key)
 
-	shard.mu.Lock()
-	defer shard.mu.Unlock()
-
+	shard.mu.RLock()
 	item, found := shard.cache[strKey]
+	shard.mu.RUnlock()
+
 	if !found || item.Expiration < time.Now().UnixNano() {
 		if found {
+			shard.mu.Lock()
 			delete(shard.cache, strKey) // Lazy expiration: remove the item if it is expired
+			shard.mu.Unlock()
 		}
 		return nil, false
 	}

--- a/node/service/internal/node/node.go
+++ b/node/service/internal/node/node.go
@@ -13,7 +13,8 @@ type (
 		IpAddr string
 		Cache  *cache.InMemoryCache
 	}
-	Node interface {
+	// CacheNode represents a cache node capable of getting and setting values.
+	CacheNode interface {
 		Get([]byte) ([]byte, bool)
 		Set([]byte, []byte)
 	}
@@ -26,7 +27,8 @@ func (n node) Set(key, value []byte) {
 	n.Cache.Set(key, value, defaultExpiration)
 }
 
-func New(ipAddr string) Node {
+// New returns a CacheNode backed by an in-memory cache.
+func New(ipAddr string) CacheNode {
 	return node{
 		IpAddr: ipAddr,
 		Cache:  cache.NewCache(),

--- a/node/service/pkg/app/app.go
+++ b/node/service/pkg/app/app.go
@@ -22,7 +22,7 @@ type Environment struct {
 	logger *slog.Logger
 
 	HTTPRegister kitHTTP.Registrar
-	node         node.Node
+	node         node.CacheNode
 
 	masterAddr string
 }
@@ -32,7 +32,7 @@ type Params struct {
 	//metrics *Metrics
 	Logger       *slog.Logger
 	HTTPRegister kitHTTP.Registrar
-	Node         node.Node
+	Node         node.CacheNode
 
 	MasterAddr string
 }

--- a/node/service/tests/integration/e2e_test.go
+++ b/node/service/tests/integration/e2e_test.go
@@ -15,7 +15,7 @@ import (
 
 type E2ETestSuite struct {
 	suite.Suite
-	node   node.Node
+	node   node.CacheNode
 	client *client.CacheAPITestClient
 	rec    *receiver.Receiver
 }


### PR DESCRIPTION
## Summary
- simplify JSON unmarshalling error handling
- preallocate hash ring memory
- use read locks for cache lookups
- rename node interface to `CacheNode`
- cache HTTP clients in the master service
- document exported constructors

## Testing
- `make test` *(fails: fetching modules blocked)*