### PR TITLE
Add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Install golangci-lint
+        run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+      - name: Run linter
+        run: make lint
+      - name: Run tests
+        run: make test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs `golangci-lint`, runs `make lint`, and `make test`

## Testing
- `make test` *(fails: forbidden downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6872b4fa29e48333bc1cc7caab096477